### PR TITLE
add intermixed add and remove test and fix sink bug

### DIFF
--- a/src/PriorityQueue.js
+++ b/src/PriorityQueue.js
@@ -32,7 +32,7 @@ function sink(data, compareFunction, index) {
                 && compareFunction(data[targetIndex + 1], data[targetIndex]) < 0) {
             targetIndex++;
         }
-        if (compareFunction(data[index], data[targetIndex]) <= 0) {
+        if (compareFunction(value, data[targetIndex]) <= 0) {
             break;
         }
         data[index] = data[targetIndex];

--- a/test/PriorityQueue.js
+++ b/test/PriorityQueue.js
@@ -37,6 +37,34 @@ suite("PriorityQueue", () => {
         equal(q.remove(), 4);
         equal(q.size, 0);
     });
+
+    test("min pq with intermixed add and remove", () => {
+        const q = PriorityQueue.newNaturalMin();
+        q.add(56);
+        q.add(73);
+        q.add(37);
+        q.add(53);
+        equal(q.remove(), 37);
+ 
+        q.add(57);
+        q.add(53);
+        equal(q.remove(), 53);
+        equal(q.remove(), 53);
+ 
+        q.add(60);
+        q.add(58);
+        q.add(72);
+        q.add(73);
+        equal(q.remove(), 56);
+        equal(q.remove(), 57);
+        equal(q.remove(), 58);
+        equal(q.remove(), 60);
+        equal(q.remove(), 72);
+        equal(q.remove(), 73);
+        equal(q.remove(), 73);
+        equal(q.size, 0);
+    });
+
     test("natural max", () => {
         const q = PriorityQueue.newNaturalMax();
         q.add(3);
@@ -88,6 +116,7 @@ suite("PriorityQueue", () => {
         equal(q.remove(), 1);
         equal(q.remove(), 2);
     });
+
     test("chained add", () => {
         const q = PriorityQueue.newNaturalMin();
         q.add(3).add(1);


### PR DESCRIPTION
In Min PQ, when sinking an element, we should stop sinking it when the original element is smaller than its children.

However, in the implementation, the stop condition is checked on an intermediate element.

This bug can be shown with an intermixed add/remove test case where is a real world use case in my project https://github.com/huiwang/brownian-motion
